### PR TITLE
Refactor: Update favorite coffee loading to use streams

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       flutter_channel: stable
       flutter_version: 3.32.8
-      coverage_excludes: '**/injection/**'
+      coverage_excludes: '**/injection/** **/routes/*.dart'
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,7 @@ jobs:
     with:
       flutter_channel: stable
       flutter_version: 3.32.8
+      min_coverage: 98
       coverage_excludes: '**/injection/** **/routes/*.dart'
 
   spell-check:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,8 +13,6 @@ on:
       - main
 
 jobs:
-  semantic-pull-request:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
 
   build:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
+      flutter_version: 3.32.8
+      coverage_excludes: '**/injection/**'
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1

--- a/lib/coffee/application/favourite/favourite_coffee_bloc.dart
+++ b/lib/coffee/application/favourite/favourite_coffee_bloc.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
+import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:coffee_app/coffee/domain/use_case/add_favourite_coffee_use_case.dart';
 import 'package:coffee_app/coffee/domain/use_case/load_favorite_coffees_use_case.dart';
 import 'package:coffee_app/coffee/domain/use_case/remove_favourite_coffee_use_case.dart';
+import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -19,8 +21,7 @@ class FavouriteCoffeeBloc
     this._addFavouriteCoffeeUseCase,
     this._removeFavouriteCoffeeUseCase,
   ) : super(FavouriteCoffeeState.initial()) {
-    on<LoadFavouriteCoffeesEvent>(_onLoadCoffeeEvent);
-
+    on<LoadFavouriteCoffeesEvent>(_onLoadFavouriteCoffeesEvent);
     on<ToggleFavouriteCoffeeEvent>(_onToggleFavouriteCoffeeEvent);
   }
 
@@ -28,23 +29,24 @@ class FavouriteCoffeeBloc
   final AddFavouriteCoffeeUseCase _addFavouriteCoffeeUseCase;
   final RemoveFavouriteCoffeeUseCase _removeFavouriteCoffeeUseCase;
 
-  Future<void> _onLoadCoffeeEvent(
+  StreamSubscription<Either<CoffeeFailure, List<Coffee>>>?
+  _favouritesSubscription;
+
+  Future<void> _onLoadFavouriteCoffeesEvent(
     LoadFavouriteCoffeesEvent event,
     Emitter<FavouriteCoffeeState> emit,
   ) async {
     emit(state.copyWith(status: FavouriteCoffeeStatus.loading));
-    final failureOrCoffee = await _loadFavoriteCoffeesUseCase.execute();
-    failureOrCoffee.fold(
-      (failure) => emit(
-        state.copyWith(
+    await emit.forEach<Either<CoffeeFailure, List<Coffee>>>(
+      _loadFavoriteCoffeesUseCase.execute(),
+      onData: (failureOrFavourites) => failureOrFavourites.fold(
+        (failure) => state.copyWith(
           status: FavouriteCoffeeStatus.error,
-          coffee: Coffee.empty(),
+          favouriteCoffees: [],
         ),
-      ),
-      (coffees) => emit(
-        state.copyWith(
+        (favourites) => state.copyWith(
           status: FavouriteCoffeeStatus.loaded,
-          favouriteCoffees: coffees,
+          favouriteCoffees: favourites,
         ),
       ),
     );
@@ -60,5 +62,11 @@ class FavouriteCoffeeBloc
       await _addFavouriteCoffeeUseCase.execute(event.coffee);
     }
     add(const LoadFavouriteCoffeesEvent());
+  }
+
+  @override
+  Future<void> close() async {
+    await _favouritesSubscription?.cancel();
+    return super.close();
   }
 }

--- a/lib/coffee/application/single/coffee_bloc.dart
+++ b/lib/coffee/application/single/coffee_bloc.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:coffee_app/coffee/domain/use_case/load_coffee_use_case.dart';
 import 'package:coffee_app/coffee/domain/use_case/load_favorite_coffees_use_case.dart';
+import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -21,13 +23,16 @@ class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
   final LoadCoffeeUseCase _loadCoffeeUseCase;
   final LoadFavoriteCoffeesUseCase _loadFavoriteCoffeesUseCase;
 
+  StreamSubscription<Either<CoffeeFailure, List<Coffee>>>?
+  _favouritesSubscription;
+
   Future<void> _onLoadCoffeeEvent(
     LoadCoffeeEvent event,
     Emitter<CoffeeState> emit,
   ) async {
     emit(state.copyWith(status: CoffeeStatus.loading));
     final failureOrCoffee = await _loadCoffeeUseCase.execute();
-    final failureOrFavourites = await _loadFavoriteCoffeesUseCase.execute();
+
     failureOrCoffee.fold(
       (failure) => emit(
         state.copyWith(
@@ -35,13 +40,16 @@ class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
           coffee: Coffee.empty(),
         ),
       ),
-      (coffee) => emit(
-        state.copyWith(
-          status: CoffeeStatus.loaded,
-          coffee: coffee,
-          favouriteCoffees: failureOrFavourites.getOrElse(() => []),
-        ),
-      ),
+      (coffee) {
+        emit(
+          state.copyWith(
+            status: CoffeeStatus.loaded,
+            coffee: coffee,
+            favouriteCoffees: [],
+          ),
+        );
+        add(const RefreshFavouriteCoffeeEvent());
+      },
     );
   }
 
@@ -49,21 +57,25 @@ class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
     RefreshFavouriteCoffeeEvent event,
     Emitter<CoffeeState> emit,
   ) async {
-    emit(state.copyWith(status: CoffeeStatus.loading));
-    final failureOrFavourites = await _loadFavoriteCoffeesUseCase.execute();
-    failureOrFavourites.fold(
-      (failure) => emit(
-        state.copyWith(
+    emit(state.copyWith(status: CoffeeStatus.loadingFavourites));
+    await emit.forEach<Either<CoffeeFailure, List<Coffee>>>(
+      _loadFavoriteCoffeesUseCase.execute(),
+      onData: (failureOrFavourites) => failureOrFavourites.fold(
+        (failure) => state.copyWith(
           status: CoffeeStatus.error,
           favouriteCoffees: [],
         ),
-      ),
-      (favourites) => emit(
-        state.copyWith(
+        (favourites) => state.copyWith(
           status: CoffeeStatus.loaded,
           favouriteCoffees: favourites,
         ),
       ),
     );
+  }
+
+  @override
+  Future<void> close() async {
+    await _favouritesSubscription?.cancel();
+    return super.close();
   }
 }

--- a/lib/coffee/application/single/coffee_state.dart
+++ b/lib/coffee/application/single/coffee_state.dart
@@ -3,6 +3,7 @@ part of 'coffee_bloc.dart';
 enum CoffeeStatus {
   initial,
   loading,
+  loadingFavourites,
   loaded,
   error,
 }

--- a/lib/coffee/domain/use_case/load_favorite_coffees_use_case.dart
+++ b/lib/coffee/domain/use_case/load_favorite_coffees_use_case.dart
@@ -3,5 +3,5 @@ import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:dartz/dartz.dart';
 
 abstract class LoadFavoriteCoffeesUseCase {
-  Future<Either<CoffeeFailure, List<Coffee>>> execute();
+  Stream<Either<CoffeeFailure, List<Coffee>>> execute();
 }

--- a/lib/coffee/infrastructure/repository/coffee_repository.dart
+++ b/lib/coffee/infrastructure/repository/coffee_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:get_storage/get_storage.dart';
@@ -43,7 +44,21 @@ class CoffeeRepository {
     }
   }
 
-  Future<List<Map<String, dynamic>>> getFavoriteCoffees() async {
+  Stream<List<Map<String, dynamic>>> getFavoriteCoffees() {
+    final controller = StreamController<List<Map<String, dynamic>>>();
+    void emitFavorites(_) {
+      controller.add(_getFavoriteCoffeesList());
+    }
+
+    emitFavorites(null);
+
+    _getStorage.listenKey(_key, emitFavorites);
+
+    controller.onCancel = controller.close;
+    return controller.stream;
+  }
+
+  List<Map<String, dynamic>> _getFavoriteCoffeesList() {
     final favoriteCoffees = _getStorage.read<List<dynamic>>(_key) ?? [];
     return favoriteCoffees
         .map((coffee) => jsonDecode(coffee as String) as Map<String, dynamic>)

--- a/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
+++ b/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
@@ -11,17 +11,16 @@ class LoadFavouriteCoffees implements LoadFavoriteCoffeesUseCase {
 
   final CoffeeRepository _coffeeRepository;
   @override
-  Future<Either<CoffeeFailure, List<Coffee>>> execute() async {
+  Stream<Either<CoffeeFailure, List<Coffee>>> execute() async* {
     try {
-      final coffeesData = await _coffeeRepository.getFavoriteCoffees();
-
-      final coffees = coffeesData.map((coffeeData) {
-        return Coffee(url: coffeeData['url'] as String);
-      }).toList();
-
-      return right(coffees);
+      yield* _coffeeRepository.getFavoriteCoffees().map((coffeesData) {
+        final coffees = coffeesData.map((coffeeData) {
+          return Coffee(url: coffeeData['url'] as String);
+        }).toList();
+        return right(coffees);
+      });
     } on Exception catch (_) {
-      return left(CoffeeNotFoundFailure());
+      yield left(CoffeeNotFoundFailure());
     }
   }
 }

--- a/lib/coffee/presentation/coffee_page.dart
+++ b/lib/coffee/presentation/coffee_page.dart
@@ -43,7 +43,8 @@ class CoffeePage extends StatelessWidget {
               child: CircularProgressIndicator(),
             ),
             CoffeeStatus.error => const CoffeeErrorWidget(),
-            CoffeeStatus.loaded => CoffeeIndividualWidget(
+            CoffeeStatus.loaded ||
+            CoffeeStatus.loadingFavourites => CoffeeIndividualWidget(
               coffee: state.coffee,
               favouriteCoffees: state.favouriteCoffees,
             ),

--- a/lib/coffee/presentation/widgets/coffee_individual_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_individual_widget.dart
@@ -1,5 +1,3 @@
-import 'package:coffee_app/coffee/application/favourite/favourite_coffee_bloc.dart'
-    as fav_coffee_bloc;
 import 'package:coffee_app/coffee/application/single/coffee_bloc.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:coffee_app/coffee/presentation/widgets/coffee_card.dart';
@@ -21,42 +19,28 @@ class CoffeeIndividualWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = context.l10n;
 
-    return BlocListener<
-      fav_coffee_bloc.FavouriteCoffeeBloc,
-      fav_coffee_bloc.FavouriteCoffeeState
-    >(
-      listenWhen: (previous, current) {
-        return previous.status != current.status ||
-            previous.favouriteCoffees != current.favouriteCoffees;
-      },
-      listener: (context, state) {
-        if (state.status == fav_coffee_bloc.FavouriteCoffeeStatus.loaded) {
-          context.read<CoffeeBloc>().add(const RefreshFavouriteCoffeeEvent());
-        }
-      },
-      child: BlocBuilder<CoffeeBloc, CoffeeState>(
-        builder: (context, state) {
-          final isFavourite = state.favouriteCoffees.contains(coffee);
-          return Center(
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  CoffeeCard(isFavourite: isFavourite, coffee: coffee),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () {
-                      context.read<CoffeeBloc>().add(const LoadCoffeeEvent());
-                    },
-                    child: Text(l10n.coffeeReload),
-                  ),
-                ],
-              ),
+    return BlocBuilder<CoffeeBloc, CoffeeState>(
+      builder: (context, state) {
+        final isFavourite = state.favouriteCoffees.contains(coffee);
+        return Center(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CoffeeCard(isFavourite: isFavourite, coffee: coffee),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () {
+                    context.read<CoffeeBloc>().add(const LoadCoffeeEvent());
+                  },
+                  child: Text(l10n.coffeeReload),
+                ),
+              ],
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/_mock/repository/mocked_coffee_repository.dart
+++ b/test/_mock/repository/mocked_coffee_repository.dart
@@ -28,7 +28,7 @@ class MockedCoffeeRepository extends Mock implements CoffeeRepository {
   }
 
   void mockGetFavouriteCoffees({required Map<String, String> expected}) {
-    when(getFavoriteCoffees).thenAnswer((_) async => [expected]);
+    when(getFavoriteCoffees).thenAnswer((_) => Stream.value([expected]));
   }
 
   void mockGetFavouriteCoffeesError() {

--- a/test/_mock/third_party/mocked_get_storage.dart
+++ b/test/_mock/third_party/mocked_get_storage.dart
@@ -13,4 +13,10 @@ class MockedGetStorage extends Mock implements GetStorage {
       () => read<List<dynamic>>(key),
     ).thenReturn(expected);
   }
+
+  void mockListenKey() {
+    when(
+      () => listenKey(any(), any()),
+    ).thenAnswer((_) => () {});
+  }
 }

--- a/test/_mock/use_case/mocked_load_favourite_coffees_use_case.dart
+++ b/test/_mock/use_case/mocked_load_favourite_coffees_use_case.dart
@@ -7,10 +7,12 @@ import 'package:mocktail/mocktail.dart';
 class MockedLoadFavouriteCoffeesUseCase extends Mock
     implements LoadFavoriteCoffeesUseCase {
   void mockExecute(List<Coffee> expected) {
-    when(execute).thenAnswer((_) async => right(expected));
+    when(execute).thenAnswer((_) => Stream.value(right(expected)));
   }
 
   void mockLoadCoffeesError() {
-    when(execute).thenAnswer((_) async => left(CoffeeNotFoundFailure()));
+    when(
+      execute,
+    ).thenAnswer((_) => Stream.value(left(CoffeeNotFoundFailure())));
   }
 }

--- a/test/coffee/application/coffee_bloc_test.dart
+++ b/test/coffee/application/coffee_bloc_test.dart
@@ -72,6 +72,16 @@ void main() {
           const CoffeeState(
             status: CoffeeStatus.loaded,
             coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
+            favouriteCoffees: [],
+          ),
+          const CoffeeState(
+            status: CoffeeStatus.loadingFavourites,
+            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
+            favouriteCoffees: [],
+          ),
+          const CoffeeState(
+            status: CoffeeStatus.loaded,
+            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
             favouriteCoffees: [
               Coffee(url: 'https://example.com/coffee1.jpg'),
               Coffee(url: 'https://example.com/coffee2.jpg'),
@@ -103,7 +113,7 @@ void main() {
         },
         expect: () => [
           const CoffeeState(
-            status: CoffeeStatus.loading,
+            status: CoffeeStatus.loadingFavourites,
             coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
             favouriteCoffees: [],
           ),
@@ -137,7 +147,7 @@ void main() {
         },
         expect: () => [
           const CoffeeState(
-            status: CoffeeStatus.loading,
+            status: CoffeeStatus.loadingFavourites,
             coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
             favouriteCoffees: [],
           ),

--- a/test/coffee/infrastructure/repository/coffee_repository_test.dart
+++ b/test/coffee/infrastructure/repository/coffee_repository_test.dart
@@ -109,15 +109,18 @@ void main() {
 
     group('getFavoriteCoffees', () {
       test(
-        'getFavoriteCoffees should return a list of favorite coffees',
+        'should return a list of favorite coffees',
         () async {
           final coffee = {'file': 'https://example.com/coffee.jpg'};
-          mockedGetStorage.mockRead(
-            key: storageKey,
-            expected: [jsonEncode(coffee)],
-          );
+          mockedGetStorage
+            ..mockRead(
+              key: storageKey,
+              expected: [jsonEncode(coffee)],
+            )
+            ..mockListenKey();
 
-          final result = await coffeeRepository.getFavoriteCoffees();
+          final stream = coffeeRepository.getFavoriteCoffees();
+          final result = await stream.first;
 
           expect(result, isA<List<Map<String, dynamic>>>());
           expect(result.length, 1);
@@ -126,11 +129,14 @@ void main() {
       );
 
       test(
-        'getFavoriteCoffees should return an empty list if no favorites',
+        'should return an empty list if no favorites',
         () async {
-          mockedGetStorage.mockRead(key: storageKey, expected: null);
+          mockedGetStorage
+            ..mockRead(key: storageKey, expected: null)
+            ..mockListenKey();
 
-          final result = await coffeeRepository.getFavoriteCoffees();
+          final stream = coffeeRepository.getFavoriteCoffees();
+          final result = await stream.first;
 
           expect(result, isA<List<Map<String, dynamic>>>());
           expect(result.isEmpty, true);

--- a/test/coffee/infrastructure/use_case/load_favourite_coffees_test.dart
+++ b/test/coffee/infrastructure/use_case/load_favourite_coffees_test.dart
@@ -22,7 +22,8 @@ void main() {
           expected: {'url': 'https://example.com/coffee.jpg'},
         );
 
-        await loadFavouriteCoffee.execute();
+        final stream = loadFavouriteCoffee.execute();
+        await stream.first;
 
         verify(() => mockedCoffeeRepository.getFavoriteCoffees()).called(1);
         verifyNoMoreInteractions(mockedCoffeeRepository);
@@ -33,7 +34,8 @@ void main() {
           expected: {'url': 'https://example.com/coffee1.jpg'},
         );
 
-        final result = await loadFavouriteCoffee.execute();
+        final stream = loadFavouriteCoffee.execute();
+        final result = await stream.first;
 
         result.fold(
           (failure) => fail('Expected right, got left: $failure'),
@@ -49,7 +51,8 @@ void main() {
       test('should return CoffeeNotFoundFailure on error', () async {
         mockedCoffeeRepository.mockGetFavouriteCoffeesError();
 
-        final result = await loadFavouriteCoffee.execute();
+        final stream = loadFavouriteCoffee.execute();
+        final result = await stream.first;
 
         expect(result.isLeft(), isTrue);
         result.fold(

--- a/test/coffee/presentation/coffee_individual_widget_test.dart
+++ b/test/coffee/presentation/coffee_individual_widget_test.dart
@@ -86,45 +86,6 @@ void main() {
     );
 
     testWidgets(
-      'should call refresh favourite coffees when favourite coffee '
-      'list is updated',
-      (tester) async {
-        mockedFavouriteCoffeesBloc
-          ..mockState(
-            const fav_coffee_bloc.FavouriteCoffeeState(
-              status: fav_coffee_bloc.FavouriteCoffeeStatus.loaded,
-              favouriteCoffees: [],
-            ),
-          )
-          ..mockListen([
-            const fav_coffee_bloc.FavouriteCoffeeState(
-              status: fav_coffee_bloc.FavouriteCoffeeStatus.loaded,
-              favouriteCoffees: [],
-            ),
-            fav_coffee_bloc.FavouriteCoffeeState(
-              status: fav_coffee_bloc.FavouriteCoffeeStatus.loaded,
-              favouriteCoffees: favouriteCoffees,
-            ),
-          ]);
-
-        await mockNetworkImages(
-          () async => tester.pumpApp(
-            _TesterWidget(
-              mockedBloc,
-              mockedFavouriteCoffeesBloc,
-              coffee,
-              favouriteCoffees,
-            ),
-          ),
-        );
-
-        verify(
-          () => mockedBloc.add(const RefreshFavouriteCoffeeEvent()),
-        ).called(1);
-      },
-    );
-
-    testWidgets(
       'should call load coffee when reload button is tapped',
       (tester) async {
         await mockNetworkImages(


### PR DESCRIPTION
This commit refactors the way favorite coffees are loaded and updated in the application.

Previously, favorite coffees were loaded once and then refreshed when changes occurred in the `FavouriteCoffeeBloc`.

Now, the `LoadFavoriteCoffeesUseCase` and `CoffeeRepository` return a `Stream` of favorite coffees. This allows the `CoffeeBloc` and `FavouriteCoffeeBloc` to subscribe to these streams and automatically update their state when the list of favorite coffees changes in the underlying storage.

Key changes:
- `LoadFavoriteCoffeesUseCase.execute` now returns `Stream<Either<CoffeeFailure, List<Coffee>>>`.
- `CoffeeRepository.getFavoriteCoffees` now returns `Stream<List<Map<String, dynamic>>>` and listens to `GetStorage` key changes to emit new lists.
- `CoffeeBloc` and `FavouriteCoffeeBloc` now use `emit.forEach` to handle the stream of favorite coffees.
- Introduced `CoffeeStatus.loadingFavourites` to differentiate between loading a new coffee image and loading/updating the favorites list.
- Removed the explicit `RefreshFavouriteCoffeeEvent` listener from `CoffeeIndividualWidget` as updates are now handled reactively by the stream.
- Updated tests to reflect the new stream-based approach.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
