### PR TITLE
Docs: Add DartDocs to coffee domain and infrastructure

### DIFF
--- a/lib/coffee/application/favourite/favourite_coffee_bloc.dart
+++ b/lib/coffee/application/favourite/favourite_coffee_bloc.dart
@@ -13,6 +13,8 @@ import 'package:injectable/injectable.dart';
 part 'favourite_coffee_event.dart';
 part 'favourite_coffee_state.dart';
 
+/// Bloc for managing the state of favourite coffees.
+/// It handles loading, adding, and removing favourite coffees.
 @injectable
 class FavouriteCoffeeBloc
     extends Bloc<FavouriteCoffeeEvent, FavouriteCoffeeState> {

--- a/lib/coffee/application/single/coffee_bloc.dart
+++ b/lib/coffee/application/single/coffee_bloc.dart
@@ -12,6 +12,8 @@ import 'package:injectable/injectable.dart';
 part 'coffee_event.dart';
 part 'coffee_state.dart';
 
+/// Bloc for managing the state of coffee.
+/// It handles loading coffee data and refreshing the list of favorite coffees.
 @injectable
 class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
   CoffeeBloc(this._loadCoffeeUseCase, this._loadFavoriteCoffeesUseCase)

--- a/lib/coffee/domain/use_case/add_favourite_coffee_use_case.dart
+++ b/lib/coffee/domain/use_case/add_favourite_coffee_use_case.dart
@@ -2,6 +2,7 @@ import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:dartz/dartz.dart';
 
+/// Use case for adding a coffee to the favourites list.
 abstract class AddFavouriteCoffeeUseCase {
   Future<Either<CoffeeFailure, Unit>> execute(Coffee coffee);
 }

--- a/lib/coffee/domain/use_case/load_coffee_use_case.dart
+++ b/lib/coffee/domain/use_case/load_coffee_use_case.dart
@@ -2,6 +2,7 @@ import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:dartz/dartz.dart';
 
+/// Use case for loading coffee data.
 abstract class LoadCoffeeUseCase {
   Future<Either<CoffeeFailure, Coffee>> execute();
 }

--- a/lib/coffee/domain/use_case/load_favorite_coffees_use_case.dart
+++ b/lib/coffee/domain/use_case/load_favorite_coffees_use_case.dart
@@ -2,6 +2,7 @@ import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:dartz/dartz.dart';
 
+/// Use case for loading favorite coffees.
 abstract class LoadFavoriteCoffeesUseCase {
   Stream<Either<CoffeeFailure, List<Coffee>>> execute();
 }

--- a/lib/coffee/domain/use_case/remove_favourite_coffee_use_case.dart
+++ b/lib/coffee/domain/use_case/remove_favourite_coffee_use_case.dart
@@ -2,6 +2,7 @@ import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:dartz/dartz.dart';
 
+/// Use case for removing a coffee from the favourites list.
 abstract class RemoveFavouriteCoffeeUseCase {
   Future<Either<CoffeeFailure, Unit>> execute(Coffee coffee);
 }

--- a/lib/coffee/infrastructure/repository/coffee_repository.dart
+++ b/lib/coffee/infrastructure/repository/coffee_repository.dart
@@ -5,6 +5,8 @@ import 'package:get_storage/get_storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:injectable/injectable.dart';
 
+/// Repository for managing coffee data, including fetching random coffee data,
+/// saving and removing favorite coffees, and streaming favorite coffees.
 @lazySingleton
 class CoffeeRepository {
   CoffeeRepository(this._client, this._getStorage);
@@ -14,6 +16,9 @@ class CoffeeRepository {
 
   final _key = 'favorite_coffees';
 
+  /// Fetches random coffee data from an external API.
+  /// Returns a [Map<String, dynamic>] containing coffee data.
+  /// Throws an [Exception] if the request fails.
   Future<Map<String, dynamic>> fetchCoffeeData() async {
     final response = await _client.get(
       Uri.parse('https://coffee.alexflipnote.dev/random.json'),
@@ -26,6 +31,13 @@ class CoffeeRepository {
     }
   }
 
+  /// Saves a coffee to the favorites list.
+  /// If the coffee is already in the favorites, it will not be added again.
+  /// The coffee is stored as a JSON string in the GetStorage.
+  /// Throws an [Exception] if the operation fails.
+  ///
+  /// [coffee] is a [Map<String, dynamic>] representing the coffee data.
+  /// Example: `{'url': 'https://example.com/coffee.jpg'}`
   Future<void> saveFavoriteCoffee(Map<String, dynamic> coffee) async {
     final encodedCoffee = jsonEncode(coffee);
     final favoriteCoffees = _getStorage.read<List<dynamic>>(_key) ?? [];
@@ -35,6 +47,10 @@ class CoffeeRepository {
     }
   }
 
+  /// Removes a coffee from the favorites list.
+  /// If the coffee is not in the favorites, it will not be removed.
+  /// The coffee is identified by its JSON string representation.
+  /// Throws an [Exception] if the operation fails.
   Future<void> removeFavoriteCoffee(Map<String, dynamic> coffee) async {
     final encodedCoffee = jsonEncode(coffee);
     final favoriteCoffees = _getStorage.read<List<dynamic>>(_key) ?? [];
@@ -44,6 +60,21 @@ class CoffeeRepository {
     }
   }
 
+  /// Streams the list of favorite coffees.
+  /// The stream emits a list of coffees, where each coffee is represented as a
+  /// [Map<String, dynamic>].
+  /// The list is updated whenever a favorite coffee is added or removed.
+  /// The coffees are stored as JSON strings in the GetStorage.
+  /// Example of a coffee map: `{'url': 'https://example.com/coffee.jpg'}`
+  /// Returns a [Stream] of lists of coffee maps.
+  /// Each map contains the coffee data,
+  /// such as the URL of the coffee image.
+  /// The stream will emit an empty list if there are no favorite coffees.
+  /// The stream will automatically close when the controller is canceled.
+  /// Throws an [Exception] if the stream cannot be created.
+  ///
+  /// Example of a list of coffee maps:
+  /// `[{'url': 'https://example.com/coffee1.jpg'}, {'url': 'https://example.com/coffee2.jpg'}]`
   Stream<List<Map<String, dynamic>>> getFavoriteCoffees() {
     final controller = StreamController<List<Map<String, dynamic>>>();
     void emitFavorites(_) {
@@ -58,6 +89,12 @@ class CoffeeRepository {
     return controller.stream;
   }
 
+  /// Retrieves the list of favorite coffees from the GetStorage.
+  /// The coffees are stored as JSON strings and are decoded into a list of maps
+  /// Each map contains the coffee data, such as the URL of the coffee image.
+  /// Returns a [List<Map<String, dynamic>]> containing the favorite coffees.
+  /// If there are no favorite coffees, an empty list is returned.
+  /// Throws an [Exception] if the data cannot be retrieved.
   List<Map<String, dynamic>> _getFavoriteCoffeesList() {
     final favoriteCoffees = _getStorage.read<List<dynamic>>(_key) ?? [];
     return favoriteCoffees

--- a/lib/coffee/infrastructure/use_case/add_favourite_coffee.dart
+++ b/lib/coffee/infrastructure/use_case/add_favourite_coffee.dart
@@ -10,6 +10,7 @@ class AddFavouriteCoffee implements AddFavouriteCoffeeUseCase {
   AddFavouriteCoffee(this._coffeeRepository);
 
   final CoffeeRepository _coffeeRepository;
+
   @override
   Future<Either<CoffeeFailure, Unit>> execute(Coffee coffee) async {
     try {

--- a/lib/coffee/infrastructure/use_case/load_coffee.dart
+++ b/lib/coffee/infrastructure/use_case/load_coffee.dart
@@ -10,6 +10,7 @@ class LoadCoffee implements LoadCoffeeUseCase {
   LoadCoffee(this._coffeeRepository);
 
   final CoffeeRepository _coffeeRepository;
+
   @override
   Future<Either<CoffeeFailure, Coffee>> execute() async {
     try {

--- a/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
+++ b/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
@@ -10,6 +10,7 @@ class LoadFavouriteCoffees implements LoadFavoriteCoffeesUseCase {
   LoadFavouriteCoffees(this._coffeeRepository);
 
   final CoffeeRepository _coffeeRepository;
+
   @override
   Stream<Either<CoffeeFailure, List<Coffee>>> execute() async* {
     try {

--- a/lib/coffee/infrastructure/use_case/remove_favourite_coffee.dart
+++ b/lib/coffee/infrastructure/use_case/remove_favourite_coffee.dart
@@ -10,6 +10,7 @@ class RemoveFavouriteCoffee implements RemoveFavouriteCoffeeUseCase {
   RemoveFavouriteCoffee(this._coffeeRepository);
 
   final CoffeeRepository _coffeeRepository;
+
   @override
   Future<Either<CoffeeFailure, Unit>> execute(Coffee coffee) async {
     try {


### PR DESCRIPTION
This commit adds DartDoc comments to various classes and methods within the coffee domain and infrastructure layers. This improves code readability and maintainability by providing clear explanations of the purpose and functionality of these components.

Specifically, DartDocs have been added to:
- Use case interfaces (`AddFavouriteCoffeeUseCase`, `RemoveFavouriteCoffeeUseCase`, `LoadCoffeeUseCase`, `LoadFavoriteCoffeesUseCase`)
- Use case implementations (constructors)
- `CoffeeRepository` and its methods
- `CoffeeBloc`
- `FavouriteCoffeeBloc`

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
