### PR TITLE
Refactor: Improve CoffeeCard image loading

### DIFF
--- a/lib/coffee/presentation/widgets/coffee_card.dart
+++ b/lib/coffee/presentation/widgets/coffee_card.dart
@@ -36,11 +36,17 @@ class CoffeeCard extends StatelessWidget {
               },
             ),
             const SizedBox(height: 16),
-            CachedNetworkImage(
-              imageUrl: coffee.url,
-              width: 300,
-              fit: BoxFit.contain,
-              errorWidget: (context, url, error) => const Icon(Icons.error),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 400),
+              child: CachedNetworkImage(
+                imageUrl: coffee.url,
+                width: 300,
+                fit: BoxFit.contain,
+                placeholder: (context, url) => const Center(
+                  child: ColoredBox(color: Colors.grey),
+                ),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
+              ),
             ),
           ],
         ),

--- a/lib/coffee/presentation/widgets/coffee_card_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_card_widget.dart
@@ -4,8 +4,8 @@ import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class CoffeeCard extends StatelessWidget {
-  const CoffeeCard({
+class CoffeeCardWidget extends StatelessWidget {
+  const CoffeeCardWidget({
     required this.isFavourite,
     required this.coffee,
     super.key,

--- a/lib/coffee/presentation/widgets/coffee_individual_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_individual_widget.dart
@@ -1,6 +1,6 @@
 import 'package:coffee_app/coffee/application/single/coffee_bloc.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
-import 'package:coffee_app/coffee/presentation/widgets/coffee_card.dart';
+import 'package:coffee_app/coffee/presentation/widgets/coffee_card_widget.dart';
 import 'package:coffee_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -28,7 +28,7 @@ class CoffeeIndividualWidget extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
               children: [
-                CoffeeCard(isFavourite: isFavourite, coffee: coffee),
+                CoffeeCardWidget(isFavourite: isFavourite, coffee: coffee),
                 const SizedBox(height: 16),
                 ElevatedButton(
                   onPressed: () {

--- a/lib/coffee/presentation/widgets/favorite_coffees_widget.dart
+++ b/lib/coffee/presentation/widgets/favorite_coffees_widget.dart
@@ -1,5 +1,5 @@
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
-import 'package:coffee_app/coffee/presentation/widgets/coffee_card.dart';
+import 'package:coffee_app/coffee/presentation/widgets/coffee_card_widget.dart';
 import 'package:coffee_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
@@ -43,7 +43,7 @@ class _FavoriteCoffeesWidgetState extends State<FavoriteCoffeesWidget> {
         final coffee = widget.favouriteCoffees[index];
         final isFavourite = widget.favouriteCoffees.contains(coffee);
         return Center(
-          child: CoffeeCard(isFavourite: isFavourite, coffee: coffee),
+          child: CoffeeCardWidget(isFavourite: isFavourite, coffee: coffee),
         );
       },
     );


### PR DESCRIPTION
This commit introduces a `ConstrainedBox` with a `minHeight` of 400 for the `CachedNetworkImage` in the `CoffeeCard` widget.

Additionally, a placeholder `ColoredBox` with a grey background is now displayed while the image is loading. This provides better visual feedback to the user during image loading.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
