### PR TITLE
Refactor: Enhance favorite coffee error handling and UI

### DIFF
--- a/lib/coffee/application/favourite/favourite_coffee_bloc.dart
+++ b/lib/coffee/application/favourite/favourite_coffee_bloc.dart
@@ -58,10 +58,18 @@ class FavouriteCoffeeBloc
     ToggleFavouriteCoffeeEvent event,
     Emitter<FavouriteCoffeeState> emit,
   ) async {
+    late Either<CoffeeFailure, Unit> failureOrSuccess;
     if (state.favouriteCoffees.contains(event.coffee)) {
-      await _removeFavouriteCoffeeUseCase.execute(event.coffee);
+      failureOrSuccess = await _removeFavouriteCoffeeUseCase.execute(
+        event.coffee,
+      );
     } else {
-      await _addFavouriteCoffeeUseCase.execute(event.coffee);
+      failureOrSuccess = await _addFavouriteCoffeeUseCase.execute(
+        event.coffee,
+      );
+    }
+    if (failureOrSuccess.isLeft()) {
+      emit(state.copyWith(status: FavouriteCoffeeStatus.toggleError));
     }
     add(const LoadFavouriteCoffeesEvent());
   }

--- a/lib/coffee/application/favourite/favourite_coffee_state.dart
+++ b/lib/coffee/application/favourite/favourite_coffee_state.dart
@@ -5,6 +5,7 @@ enum FavouriteCoffeeStatus {
   loading,
   loaded,
   error,
+  toggleError,
 }
 
 final class FavouriteCoffeeState extends Equatable {

--- a/lib/coffee/domain/failure/coffee_failure.dart
+++ b/lib/coffee/domain/failure/coffee_failure.dart
@@ -3,3 +3,9 @@ import 'package:coffee_app/core/failure/failure.dart';
 abstract class CoffeeFailure extends Failure {}
 
 class CoffeeNotFoundFailure extends CoffeeFailure {}
+
+class AddFavouriteCoffeeFailure extends CoffeeFailure {}
+
+class LoadFavouritesFailure extends CoffeeFailure {}
+
+class RemoveFavouriteCoffeeFailure extends CoffeeFailure {}

--- a/lib/coffee/infrastructure/use_case/add_favourite_coffee.dart
+++ b/lib/coffee/infrastructure/use_case/add_favourite_coffee.dart
@@ -18,7 +18,7 @@ class AddFavouriteCoffee implements AddFavouriteCoffeeUseCase {
 
       return right(unit);
     } on Exception catch (_) {
-      return left(CoffeeNotFoundFailure());
+      return left(AddFavouriteCoffeeFailure());
     }
   }
 }

--- a/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
+++ b/lib/coffee/infrastructure/use_case/load_favourite_coffees.dart
@@ -21,7 +21,7 @@ class LoadFavouriteCoffees implements LoadFavoriteCoffeesUseCase {
         return right(coffees);
       });
     } on Exception catch (_) {
-      yield left(CoffeeNotFoundFailure());
+      yield left(LoadFavouritesFailure());
     }
   }
 }

--- a/lib/coffee/infrastructure/use_case/remove_favourite_coffee.dart
+++ b/lib/coffee/infrastructure/use_case/remove_favourite_coffee.dart
@@ -18,7 +18,7 @@ class RemoveFavouriteCoffee implements RemoveFavouriteCoffeeUseCase {
 
       return right(unit);
     } on Exception catch (_) {
-      return left(CoffeeNotFoundFailure());
+      return left(RemoveFavouriteCoffeeFailure());
     }
   }
 }

--- a/lib/coffee/presentation/favourite_coffees_page.dart
+++ b/lib/coffee/presentation/favourite_coffees_page.dart
@@ -23,7 +23,8 @@ class FavouriteCoffeesPage extends StatelessWidget {
               child: CircularProgressIndicator(),
             ),
             FavouriteCoffeeStatus.error => const CoffeeErrorWidget(),
-            FavouriteCoffeeStatus.loaded => FavoriteCoffeesWidget(
+            FavouriteCoffeeStatus.loaded ||
+            FavouriteCoffeeStatus.toggleError => FavoriteCoffeesWidget(
               favouriteCoffees: state.favouriteCoffees,
             ),
           },

--- a/lib/coffee/presentation/widgets/coffee_card_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_card_widget.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:coffee_app/coffee/application/favourite/favourite_coffee_bloc.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
+import 'package:coffee_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -10,45 +11,61 @@ class CoffeeCardWidget extends StatelessWidget {
     required this.coffee,
     super.key,
   });
+
   final bool isFavourite;
   final Coffee coffee;
+
   @override
   Widget build(BuildContext context) {
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.end,
+    final l10n = context.l10n;
+    return BlocListener<FavouriteCoffeeBloc, FavouriteCoffeeState>(
+      listener: (context, state) {
+        if (state.status == FavouriteCoffeeStatus.toggleError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                l10n.toggleFavouriteCoffeeError,
+              ),
+            ),
+          );
+        }
+      },
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.end,
 
-          children: [
-            IconButton(
-              icon: Icon(
-                isFavourite ? Icons.favorite : Icons.favorite_border,
-              ),
-              iconSize: 32,
-              onPressed: () {
-                context.read<FavouriteCoffeeBloc>().add(
-                  ToggleFavouriteCoffeeEvent(
-                    coffee,
-                  ),
-                );
-              },
-            ),
-            const SizedBox(height: 16),
-            ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 400),
-              child: CachedNetworkImage(
-                imageUrl: coffee.url,
-                width: 300,
-                fit: BoxFit.contain,
-                placeholder: (context, url) => const Center(
-                  child: ColoredBox(color: Colors.grey),
+            children: [
+              IconButton(
+                icon: Icon(
+                  isFavourite ? Icons.favorite : Icons.favorite_border,
                 ),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                iconSize: 32,
+                onPressed: () {
+                  context.read<FavouriteCoffeeBloc>().add(
+                    ToggleFavouriteCoffeeEvent(
+                      coffee,
+                    ),
+                  );
+                },
               ),
-            ),
-          ],
+              const SizedBox(height: 16),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 400),
+                child: CachedNetworkImage(
+                  imageUrl: coffee.url,
+                  width: 300,
+                  fit: BoxFit.contain,
+                  placeholder: (context, url) => const Center(
+                    child: ColoredBox(color: Colors.grey),
+                  ),
+                  errorWidget: (context, url, error) => const Icon(Icons.error),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -23,5 +23,9 @@
   "themeModeTitle": "Switch Theme Mode",
   "@themeModeTitle": {
     "description": "Title for the theme mode switcher."
+  },
+  "toggleFavouriteCoffeeError": "Error toggling favourite coffee",
+  "@toggleFavouriteCoffeeError": {
+    "description": "This message is displayed when there is an error toggling a coffee's favourite status."
   }
 }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -23,5 +23,9 @@
   "themeModeTitle": "Cambiar modo de tema",
   "@themeModeTitle": {
     "description": "Título del conmutador de modo de tema."
+  },
+  "toggleFavouriteCoffeeError": "Error al alternar el café favorito",
+  "@toggleFavouriteCoffeeError": {
+    "description": "Este mensaje se muestra cuando hay un error al alternar el estado favorito de un café."
   }
 }

--- a/test/_mock/use_case/mocked_add_favourite_coffee_use_case.dart
+++ b/test/_mock/use_case/mocked_add_favourite_coffee_use_case.dart
@@ -10,9 +10,9 @@ class MockedAddFavouriteCoffeeUseCase extends Mock
     when(() => execute(coffee)).thenAnswer((_) async => right(unit));
   }
 
-  void mockLoadCoffeesError(Coffee coffee) {
+  void mockAddCoffeeError(Coffee coffee) {
     when(
       () => execute(coffee),
-    ).thenAnswer((_) async => left(CoffeeNotFoundFailure()));
+    ).thenAnswer((_) async => left(AddFavouriteCoffeeFailure()));
   }
 }

--- a/test/_mock/use_case/mocked_remove_favourite_coffee_use_case.dart
+++ b/test/_mock/use_case/mocked_remove_favourite_coffee_use_case.dart
@@ -10,9 +10,9 @@ class MockedRemoveFavouriteCoffeeUseCase extends Mock
     when(() => execute(coffee)).thenAnswer((_) async => right(unit));
   }
 
-  void mockLoadCoffeesError(Coffee coffee) {
+  void mockRemoveCoffeeError(Coffee coffee) {
     when(
       () => execute(coffee),
-    ).thenAnswer((_) async => left(CoffeeNotFoundFailure()));
+    ).thenAnswer((_) async => left(RemoveFavouriteCoffeeFailure()));
   }
 }

--- a/test/coffee/application/favourite_coffee_bloc_test.dart
+++ b/test/coffee/application/favourite_coffee_bloc_test.dart
@@ -164,6 +164,101 @@ void main() {
           ),
         ],
       );
+
+      blocTest<FavouriteCoffeeBloc, FavouriteCoffeeState>(
+        'should emits [loading, toggleError] when the use case return left '
+        'and the coffee is in the favourites',
+        build: () {
+          mockedLoadFavouriteCoffeesUseCase.mockExecute([
+            const Coffee(url: 'https://example.com/coffee1.jpg'),
+            const Coffee(url: 'https://example.com/coffee2.jpg'),
+          ]);
+          mockedRemoveFavouriteCoffeeUseCase.mockRemoveCoffeeError(
+            const Coffee(url: 'https://example.com/coffee1.jpg'),
+          );
+          return bloc;
+        },
+        seed: () => const FavouriteCoffeeState(
+          status: FavouriteCoffeeStatus.loaded,
+          favouriteCoffees: [
+            Coffee(url: 'https://example.com/coffee1.jpg'),
+            Coffee(url: 'https://example.com/coffee2.jpg'),
+          ],
+        ),
+        act: (FavouriteCoffeeBloc bloc) => bloc.add(
+          const ToggleFavouriteCoffeeEvent(
+            Coffee(url: 'https://example.com/coffee1.jpg'),
+          ),
+        ),
+        expect: () => [
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.toggleError,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee1.jpg'),
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loading,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee1.jpg'),
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee1.jpg'),
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+        ],
+      );
+
+      blocTest<FavouriteCoffeeBloc, FavouriteCoffeeState>(
+        'should emits [loading, toggleError] when the use case return left '
+        'and the coffee is not in the favourites',
+        build: () {
+          mockedLoadFavouriteCoffeesUseCase.mockExecute([
+            const Coffee(url: 'https://example.com/coffee2.jpg'),
+          ]);
+          mockedAddFavouriteCoffeeUseCase.mockAddCoffeeError(
+            const Coffee(url: 'https://example.com/coffee1.jpg'),
+          );
+          return bloc;
+        },
+        seed: () => const FavouriteCoffeeState(
+          status: FavouriteCoffeeStatus.loaded,
+          favouriteCoffees: [
+            Coffee(url: 'https://example.com/coffee2.jpg'),
+          ],
+        ),
+        act: (FavouriteCoffeeBloc bloc) => bloc.add(
+          const ToggleFavouriteCoffeeEvent(
+            Coffee(url: 'https://example.com/coffee1.jpg'),
+          ),
+        ),
+        expect: () => [
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.toggleError,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loading,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [
+              Coffee(url: 'https://example.com/coffee2.jpg'),
+            ],
+          ),
+        ],
+      );
     });
   });
 

--- a/test/coffee/infrastructure/use_case/add_favourite_coffee_test.dart
+++ b/test/coffee/infrastructure/use_case/add_favourite_coffee_test.dart
@@ -64,7 +64,7 @@ void main() {
 
         expect(result.isLeft(), isTrue);
         result.fold(
-          (failure) => expect(failure, isA<CoffeeNotFoundFailure>()),
+          (failure) => expect(failure, isA<AddFavouriteCoffeeFailure>()),
           (coffees) => fail('Expected left, got right: $coffees'),
         );
       });

--- a/test/coffee/infrastructure/use_case/load_favourite_coffees_test.dart
+++ b/test/coffee/infrastructure/use_case/load_favourite_coffees_test.dart
@@ -56,7 +56,7 @@ void main() {
 
         expect(result.isLeft(), isTrue);
         result.fold(
-          (failure) => expect(failure, isA<CoffeeNotFoundFailure>()),
+          (failure) => expect(failure, isA<LoadFavouritesFailure>()),
           (coffees) => fail('Expected left, got right: $coffees'),
         );
       });

--- a/test/coffee/infrastructure/use_case/remove_favourite_coffee_test.dart
+++ b/test/coffee/infrastructure/use_case/remove_favourite_coffee_test.dart
@@ -64,7 +64,7 @@ void main() {
 
         expect(result.isLeft(), isTrue);
         result.fold(
-          (failure) => expect(failure, isA<CoffeeNotFoundFailure>()),
+          (failure) => expect(failure, isA<RemoveFavouriteCoffeeFailure>()),
           (coffees) => fail('Expected left, got right: $coffees'),
         );
       });

--- a/test/coffee/presentation/coffee_card_widget_test.dart
+++ b/test/coffee/presentation/coffee_card_widget_test.dart
@@ -1,0 +1,115 @@
+import 'package:coffee_app/coffee/application/favourite/favourite_coffee_bloc.dart';
+import 'package:coffee_app/coffee/domain/model/coffee.dart';
+import 'package:coffee_app/coffee/presentation/widgets/coffee_card_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../_mock/application/mocked_favourite_coffee_bloc.dart';
+import '../../helpers/helpers.dart';
+
+void main() {
+  const coffee = Coffee(
+    url: 'https://example.com/espresso.jpg',
+  );
+  late MockedFavouriteCoffeeBloc mockedFavouriteCoffeeBloc;
+  setUp(() {
+    mockedFavouriteCoffeeBloc = MockedFavouriteCoffeeBloc()
+      ..mockState(FavouriteCoffeeState.initial());
+  });
+
+  group(CoffeeCardWidget, () {
+    testWidgets(
+      'should render with heart not filled '
+      'when coffee is not favourite',
+      (tester) async {
+        await tester.pumpApp(
+          BlocProvider<FavouriteCoffeeBloc>.value(
+            value: mockedFavouriteCoffeeBloc,
+            child: const CoffeeCardWidget(
+              isFavourite: false,
+              coffee: coffee,
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should render with heart filled '
+      'when coffee is favourite',
+      (tester) async {
+        await tester.pumpApp(
+          BlocProvider<FavouriteCoffeeBloc>.value(
+            value: mockedFavouriteCoffeeBloc,
+            child: const CoffeeCardWidget(
+              isFavourite: true,
+              coffee: coffee,
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.favorite), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'should call toggle favourite coffee event '
+      'when heart is pressed',
+      (tester) async {
+        await tester.pumpApp(
+          BlocProvider<FavouriteCoffeeBloc>.value(
+            value: mockedFavouriteCoffeeBloc,
+            child: const CoffeeCardWidget(
+              isFavourite: false,
+              coffee: coffee,
+            ),
+          ),
+        );
+
+        await tester.tap(find.byIcon(Icons.favorite_border));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockedFavouriteCoffeeBloc.add(
+            const ToggleFavouriteCoffeeEvent(coffee),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'should show snackbar with error message '
+      'when toggle favourite coffee fails',
+      (tester) async {
+        mockedFavouriteCoffeeBloc.mockListen(
+          [
+            const FavouriteCoffeeState(
+              status: FavouriteCoffeeStatus.toggleError,
+              favouriteCoffees: [coffee],
+            ),
+          ],
+        );
+
+        await tester.pumpApp(
+          BlocProvider<FavouriteCoffeeBloc>.value(
+            value: mockedFavouriteCoffeeBloc,
+            child: const Scaffold(
+              body: CoffeeCardWidget(
+                isFavourite: false,
+                coffee: coffee,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+
+        expect(find.text('Error toggling favourite coffee'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/coffee/presentation/favorite_coffees_widget_test.dart
+++ b/test/coffee/presentation/favorite_coffees_widget_test.dart
@@ -5,14 +5,16 @@ import 'package:coffee_app/coffee/presentation/widgets/favorite_coffees_widget.d
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
 
 import '../../_mock/application/mocked_favourite_coffee_bloc.dart';
 import '../../helpers/helpers.dart';
 
 void main() {
-  final mockedFavouriteCoffeesBloc = MockedFavouriteCoffeeBloc();
+  final mockedFavouriteCoffeesBloc = MockedFavouriteCoffeeBloc()
+    ..mockState(
+      FavouriteCoffeeState.initial(),
+    );
 
   group(FavoriteCoffeesWidget, () {
     testWidgets(
@@ -37,7 +39,10 @@ void main() {
 
         await mockNetworkImages(
           () async => tester.pumpApp(
-            FavoriteCoffeesWidget(favouriteCoffees: coffees),
+            BlocProvider<FavouriteCoffeeBloc>.value(
+              value: mockedFavouriteCoffeesBloc,
+              child: FavoriteCoffeesWidget(favouriteCoffees: coffees),
+            ),
           ),
         );
 
@@ -112,38 +117,6 @@ void main() {
           ),
           findsOneWidget,
         );
-      },
-    );
-
-    testWidgets(
-      'should call toggle favourite coffee when heart icon '
-      'is tapped and belong to favourites',
-      (tester) async {
-        final coffees = [
-          const Coffee(url: 'https://example.com/espresso.jpg'),
-        ];
-
-        await mockNetworkImages(
-          () async => tester.pumpApp(
-            BlocProvider<FavouriteCoffeeBloc>.value(
-              value: mockedFavouriteCoffeesBloc,
-              child: FavoriteCoffeesWidget(
-                favouriteCoffees: coffees,
-              ),
-            ),
-          ),
-        );
-
-        expect(find.byType(IconButton), findsOneWidget);
-
-        await tester.tap(find.byType(IconButton));
-        await tester.pump(const Duration(seconds: 1));
-
-        verify(
-          () => mockedFavouriteCoffeesBloc.add(
-            ToggleFavouriteCoffeeEvent(coffees.first),
-          ),
-        ).called(1);
       },
     );
   });


### PR DESCRIPTION
This commit introduces several improvements to how errors are handled and displayed when toggling favorite coffees:

- **Specific Failure Types:** Introduced more granular `CoffeeFailure` subtypes:
    - `AddFavouriteCoffeeFailure`
    - `LoadFavouritesFailure`
    - `RemoveFavouriteCoffeeFailure` This replaces the generic `CoffeeNotFoundFailure` for more precise error identification in use cases.

- **Toggle Error State:** Added a new `FavouriteCoffeeStatus.toggleError` to the `FavouriteCoffeeState`. This allows the UI to distinguish between general loading errors and errors specifically related to toggling a favorite.

- **Snackbar for Toggle Errors:** The `CoffeeCardWidget` now listens to the `FavouriteCoffeeBloc` and displays a `SnackBar` with an error message (localized) if `FavouriteCoffeeStatus.toggleError` is emitted.

- **UI Update on Toggle Error:** The `FavouriteCoffeesPage` now continues to display the list of favorite coffees even when a `toggleError` occurs, providing a better user experience than showing a generic error screen.

- **Updated Tests:**
    - Added new tests for `CoffeeCardWidget` to verify the snackbar display on toggle error.
    - Updated existing tests for use cases and `FavouriteCoffeeBloc` to reflect the new failure types and the `toggleError` state.
    - Adjusted `FavoriteCoffeesWidget` tests to correctly provide the `FavouriteCoffeeBloc`.

- **Localization:** Added new localized strings for the toggle favorite coffee error message in English and Spanish.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
