### PR TITLE
Refactor: Remove direct favorite coffee handling from CoffeeBloc

### DIFF
--- a/lib/coffee/application/favourite/favourite_coffee_bloc.dart
+++ b/lib/coffee/application/favourite/favourite_coffee_bloc.dart
@@ -71,7 +71,6 @@ class FavouriteCoffeeBloc
     if (failureOrSuccess.isLeft()) {
       emit(state.copyWith(status: FavouriteCoffeeStatus.toggleError));
     }
-    add(const LoadFavouriteCoffeesEvent());
   }
 
   @override

--- a/lib/coffee/application/single/coffee_bloc.dart
+++ b/lib/coffee/application/single/coffee_bloc.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
 
-import 'package:coffee_app/coffee/domain/failure/coffee_failure.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:coffee_app/coffee/domain/use_case/load_coffee_use_case.dart';
-import 'package:coffee_app/coffee/domain/use_case/load_favorite_coffees_use_case.dart';
-import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -16,17 +13,11 @@ part 'coffee_state.dart';
 /// It handles loading coffee data and refreshing the list of favorite coffees.
 @injectable
 class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
-  CoffeeBloc(this._loadCoffeeUseCase, this._loadFavoriteCoffeesUseCase)
-    : super(CoffeeState.initial()) {
+  CoffeeBloc(this._loadCoffeeUseCase) : super(CoffeeState.initial()) {
     on<LoadCoffeeEvent>(_onLoadCoffeeEvent);
-    on<RefreshFavouriteCoffeeEvent>(_onRefreshFavouriteCoffeeEvent);
   }
 
   final LoadCoffeeUseCase _loadCoffeeUseCase;
-  final LoadFavoriteCoffeesUseCase _loadFavoriteCoffeesUseCase;
-
-  StreamSubscription<Either<CoffeeFailure, List<Coffee>>>?
-  _favouritesSubscription;
 
   Future<void> _onLoadCoffeeEvent(
     LoadCoffeeEvent event,
@@ -47,37 +38,9 @@ class CoffeeBloc extends Bloc<CoffeeEvent, CoffeeState> {
           state.copyWith(
             status: CoffeeStatus.loaded,
             coffee: coffee,
-            favouriteCoffees: [],
           ),
         );
-        add(const RefreshFavouriteCoffeeEvent());
       },
     );
-  }
-
-  Future<void> _onRefreshFavouriteCoffeeEvent(
-    RefreshFavouriteCoffeeEvent event,
-    Emitter<CoffeeState> emit,
-  ) async {
-    emit(state.copyWith(status: CoffeeStatus.loadingFavourites));
-    await emit.forEach<Either<CoffeeFailure, List<Coffee>>>(
-      _loadFavoriteCoffeesUseCase.execute(),
-      onData: (failureOrFavourites) => failureOrFavourites.fold(
-        (failure) => state.copyWith(
-          status: CoffeeStatus.error,
-          favouriteCoffees: [],
-        ),
-        (favourites) => state.copyWith(
-          status: CoffeeStatus.loaded,
-          favouriteCoffees: favourites,
-        ),
-      ),
-    );
-  }
-
-  @override
-  Future<void> close() async {
-    await _favouritesSubscription?.cancel();
-    return super.close();
   }
 }

--- a/lib/coffee/application/single/coffee_event.dart
+++ b/lib/coffee/application/single/coffee_event.dart
@@ -10,19 +10,3 @@ final class LoadCoffeeEvent extends CoffeeEvent {
   @override
   List<Object?> get props => [];
 }
-
-final class RefreshFavouriteCoffeeEvent extends CoffeeEvent {
-  const RefreshFavouriteCoffeeEvent();
-
-  @override
-  List<Object?> get props => [];
-}
-
-final class ToggleFavouriteCoffeeEvent extends CoffeeEvent {
-  const ToggleFavouriteCoffeeEvent(this.coffee);
-
-  final Coffee coffee;
-
-  @override
-  List<Object?> get props => [coffee];
-}

--- a/lib/coffee/application/single/coffee_state.dart
+++ b/lib/coffee/application/single/coffee_state.dart
@@ -3,7 +3,6 @@ part of 'coffee_bloc.dart';
 enum CoffeeStatus {
   initial,
   loading,
-  loadingFavourites,
   loaded,
   error,
 }
@@ -12,37 +11,31 @@ final class CoffeeState extends Equatable {
   const CoffeeState({
     required this.status,
     required this.coffee,
-    required this.favouriteCoffees,
   });
 
   factory CoffeeState.initial() {
     return CoffeeState(
       status: CoffeeStatus.initial,
       coffee: Coffee.empty(),
-      favouriteCoffees: const [],
     );
   }
 
   final CoffeeStatus status;
   final Coffee coffee;
-  final List<Coffee> favouriteCoffees;
 
   @override
   List<Object?> get props => [
     status,
     coffee,
-    favouriteCoffees,
   ];
 
   CoffeeState copyWith({
     required CoffeeStatus status,
     Coffee? coffee,
-    List<Coffee>? favouriteCoffees,
   }) {
     return CoffeeState(
       status: status,
       coffee: coffee ?? this.coffee,
-      favouriteCoffees: favouriteCoffees ?? this.favouriteCoffees,
     );
   }
 }

--- a/lib/coffee/presentation/coffee_page.dart
+++ b/lib/coffee/presentation/coffee_page.dart
@@ -51,10 +51,8 @@ class CoffeePage extends StatelessWidget {
               child: CircularProgressIndicator(),
             ),
             CoffeeStatus.error => const CoffeeErrorWidget(),
-            CoffeeStatus.loaded ||
-            CoffeeStatus.loadingFavourites => CoffeeIndividualWidget(
+            CoffeeStatus.loaded => CoffeeIndividualWidget(
               coffee: state.coffee,
-              favouriteCoffees: state.favouriteCoffees,
             ),
           },
         );

--- a/lib/coffee/presentation/favourite_coffees_page.dart
+++ b/lib/coffee/presentation/favourite_coffees_page.dart
@@ -23,10 +23,7 @@ class FavouriteCoffeesPage extends StatelessWidget {
               child: CircularProgressIndicator(),
             ),
             FavouriteCoffeeStatus.error => const CoffeeErrorWidget(),
-            FavouriteCoffeeStatus.loaded ||
-            FavouriteCoffeeStatus.toggleError => FavoriteCoffeesWidget(
-              favouriteCoffees: state.favouriteCoffees,
-            ),
+            _ => const FavoriteCoffeesWidget(),
           },
         );
       },

--- a/lib/coffee/presentation/widgets/coffee_card_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_card_widget.dart
@@ -7,18 +7,16 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CoffeeCardWidget extends StatelessWidget {
   const CoffeeCardWidget({
-    required this.isFavourite,
     required this.coffee,
     super.key,
   });
 
-  final bool isFavourite;
   final Coffee coffee;
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    return BlocListener<FavouriteCoffeeBloc, FavouriteCoffeeState>(
+    return BlocConsumer<FavouriteCoffeeBloc, FavouriteCoffeeState>(
       listener: (context, state) {
         if (state.status == FavouriteCoffeeStatus.toggleError) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -30,44 +28,48 @@ class CoffeeCardWidget extends StatelessWidget {
           );
         }
       },
-      child: Card(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.end,
+      builder: (context, state) {
+        final isFavourite = state.favouriteCoffees.contains(coffee);
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
 
-            children: [
-              IconButton(
-                icon: Icon(
-                  isFavourite ? Icons.favorite : Icons.favorite_border,
-                ),
-                iconSize: 32,
-                onPressed: () {
-                  context.read<FavouriteCoffeeBloc>().add(
-                    ToggleFavouriteCoffeeEvent(
-                      coffee,
-                    ),
-                  );
-                },
-              ),
-              const SizedBox(height: 16),
-              ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 400),
-                child: CachedNetworkImage(
-                  imageUrl: coffee.url,
-                  width: 300,
-                  fit: BoxFit.contain,
-                  placeholder: (context, url) => const Center(
-                    child: ColoredBox(color: Colors.grey),
+              children: [
+                IconButton(
+                  icon: Icon(
+                    isFavourite ? Icons.favorite : Icons.favorite_border,
                   ),
-                  errorWidget: (context, url, error) => const Icon(Icons.error),
+                  iconSize: 32,
+                  onPressed: () {
+                    context.read<FavouriteCoffeeBloc>().add(
+                      ToggleFavouriteCoffeeEvent(
+                        coffee,
+                      ),
+                    );
+                  },
                 ),
-              ),
-            ],
+                const SizedBox(height: 16),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 400),
+                  child: CachedNetworkImage(
+                    imageUrl: coffee.url,
+                    width: 300,
+                    fit: BoxFit.contain,
+                    placeholder: (context, url) => const Center(
+                      child: ColoredBox(color: Colors.grey),
+                    ),
+                    errorWidget: (context, url, error) =>
+                        const Icon(Icons.error),
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/coffee/presentation/widgets/coffee_individual_widget.dart
+++ b/lib/coffee/presentation/widgets/coffee_individual_widget.dart
@@ -8,12 +8,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 class CoffeeIndividualWidget extends StatelessWidget {
   const CoffeeIndividualWidget({
     required this.coffee,
-    required this.favouriteCoffees,
+
     super.key,
   });
 
   final Coffee coffee;
-  final List<Coffee> favouriteCoffees;
 
   @override
   Widget build(BuildContext context) {
@@ -21,14 +20,13 @@ class CoffeeIndividualWidget extends StatelessWidget {
 
     return BlocBuilder<CoffeeBloc, CoffeeState>(
       builder: (context, state) {
-        final isFavourite = state.favouriteCoffees.contains(coffee);
         return Center(
           child: SingleChildScrollView(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
               children: [
-                CoffeeCardWidget(isFavourite: isFavourite, coffee: coffee),
+                CoffeeCardWidget(coffee: coffee),
                 const SizedBox(height: 16),
                 ElevatedButton(
                   onPressed: () {

--- a/lib/coffee/presentation/widgets/favorite_coffees_widget.dart
+++ b/lib/coffee/presentation/widgets/favorite_coffees_widget.dart
@@ -1,15 +1,14 @@
+import 'package:coffee_app/coffee/application/favourite/favourite_coffee_bloc.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:coffee_app/coffee/presentation/widgets/coffee_card_widget.dart';
 import 'package:coffee_app/l10n/l10n.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class FavoriteCoffeesWidget extends StatefulWidget {
   const FavoriteCoffeesWidget({
-    required this.favouriteCoffees,
     super.key,
   });
-
-  final List<Coffee> favouriteCoffees;
 
   @override
   State<FavoriteCoffeesWidget> createState() => _FavoriteCoffeesWidgetState();
@@ -32,18 +31,29 @@ class _FavoriteCoffeesWidgetState extends State<FavoriteCoffeesWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    if (widget.favouriteCoffees.isEmpty) {
-      return Center(child: Text(l10n.coffeesEmpty));
-    }
-    return PageView.builder(
-      controller: _pageController,
-      itemCount: widget.favouriteCoffees.length,
-      itemBuilder: (context, index) {
-        final coffee = widget.favouriteCoffees[index];
-        final isFavourite = widget.favouriteCoffees.contains(coffee);
-        return Center(
-          child: CoffeeCardWidget(isFavourite: isFavourite, coffee: coffee),
+    return BlocSelector<
+      FavouriteCoffeeBloc,
+      FavouriteCoffeeState,
+      List<Coffee>
+    >(
+      selector: (state) => state.favouriteCoffees,
+      builder: (context, favouriteCoffees) {
+        final l10n = context.l10n;
+        if (favouriteCoffees.isEmpty) {
+          return Center(
+            child: Text(l10n.coffeesEmpty),
+          );
+        }
+        return PageView.builder(
+          controller: _pageController,
+          itemCount: favouriteCoffees.length,
+          itemBuilder: (context, index) {
+            final coffee = favouriteCoffees[index];
+
+            return Center(
+              child: CoffeeCardWidget(coffee: coffee),
+            );
+          },
         );
       },
     );

--- a/lib/injection/injection.config.dart
+++ b/lib/injection/injection.config.dart
@@ -68,10 +68,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i331.AddFavouriteCoffee(gh<_i920.CoffeeRepository>()),
     );
     gh.factory<_i445.CoffeeBloc>(
-      () => _i445.CoffeeBloc(
-        gh<_i474.LoadCoffeeUseCase>(),
-        gh<_i521.LoadFavoriteCoffeesUseCase>(),
-      ),
+      () => _i445.CoffeeBloc(gh<_i474.LoadCoffeeUseCase>()),
     );
     gh.factory<_i843.FavouriteCoffeeBloc>(
       () => _i843.FavouriteCoffeeBloc(

--- a/test/coffee/application/coffee_bloc_test.dart
+++ b/test/coffee/application/coffee_bloc_test.dart
@@ -4,21 +4,16 @@ import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../_mock/use_case/mocked_load_coffee_use_case.dart';
-import '../../_mock/use_case/mocked_load_favourite_coffees_use_case.dart';
 
 void main() {
   late MockedLoadCoffeeUseCase mockedLoadCoffeeUseCase;
-  late MockedLoadFavouriteCoffeesUseCase mockedLoadFavouriteCoffeesUseCase;
 
   late CoffeeBloc bloc;
 
   setUp(() {
-    mockedLoadFavouriteCoffeesUseCase = MockedLoadFavouriteCoffeesUseCase();
-
     mockedLoadCoffeeUseCase = MockedLoadCoffeeUseCase();
     bloc = CoffeeBloc(
       mockedLoadCoffeeUseCase,
-      mockedLoadFavouriteCoffeesUseCase,
     );
   });
 
@@ -32,7 +27,6 @@ void main() {
         'should emits [loading, error] when the use case return left',
         build: () {
           mockedLoadCoffeeUseCase.mockLoadCoffeesError();
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([]);
           return bloc;
         },
         act: (CoffeeBloc bloc) => bloc.add(const LoadCoffeeEvent()),
@@ -40,12 +34,10 @@ void main() {
           CoffeeState(
             status: CoffeeStatus.loading,
             coffee: Coffee.empty(),
-            favouriteCoffees: const [],
           ),
           CoffeeState(
             status: CoffeeStatus.error,
             coffee: Coffee.empty(),
-            favouriteCoffees: const [],
           ),
         ],
       );
@@ -56,10 +48,7 @@ void main() {
           mockedLoadCoffeeUseCase.mockLoadCoffee(
             const Coffee(url: 'https://example.com/coffee1.jpg'),
           );
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee1.jpg'),
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-          ]);
+
           return bloc;
         },
         act: (CoffeeBloc bloc) => bloc.add(const LoadCoffeeEvent()),
@@ -67,94 +56,10 @@ void main() {
           CoffeeState(
             status: CoffeeStatus.loading,
             coffee: Coffee.empty(),
-            favouriteCoffees: const [],
           ),
           const CoffeeState(
             status: CoffeeStatus.loaded,
             coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [],
-          ),
-          const CoffeeState(
-            status: CoffeeStatus.loadingFavourites,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [],
-          ),
-          const CoffeeState(
-            status: CoffeeStatus.loaded,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-        ],
-      );
-    });
-
-    group(RefreshFavouriteCoffeeEvent, () {
-      blocTest<CoffeeBloc, CoffeeState>(
-        'should refresh favourite coffees',
-        build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee1.jpg'),
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-          ]);
-          return bloc;
-        },
-        seed: () => const CoffeeState(
-          status: CoffeeStatus.loaded,
-          coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-          favouriteCoffees: [],
-        ),
-        act: (CoffeeBloc bloc) {
-          bloc.add(
-            const RefreshFavouriteCoffeeEvent(),
-          );
-        },
-        expect: () => [
-          const CoffeeState(
-            status: CoffeeStatus.loadingFavourites,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [],
-          ),
-          const CoffeeState(
-            status: CoffeeStatus.loaded,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-        ],
-      );
-
-      blocTest<CoffeeBloc, CoffeeState>(
-        'should refresh favourite coffees with empty favourites when the '
-        'use case returns error',
-        build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockLoadCoffeesError();
-          return bloc;
-        },
-        seed: () => const CoffeeState(
-          status: CoffeeStatus.loaded,
-          coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-          favouriteCoffees: [],
-        ),
-        act: (CoffeeBloc bloc) {
-          bloc.add(
-            const RefreshFavouriteCoffeeEvent(),
-          );
-        },
-        expect: () => [
-          const CoffeeState(
-            status: CoffeeStatus.loadingFavourites,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [],
-          ),
-          const CoffeeState(
-            status: CoffeeStatus.error,
-            coffee: Coffee(url: 'https://example.com/coffee1.jpg'),
-            favouriteCoffees: [],
           ),
         ],
       );
@@ -165,23 +70,6 @@ void main() {
     test('LoadCoffeesEvent is comparable', () {
       const event1 = LoadCoffeeEvent();
       const event2 = LoadCoffeeEvent();
-
-      expect(event1 == event2, isTrue);
-      expect(event1.props, event2.props);
-    });
-
-    test('RefreshFavouriteCoffeeEvent is comparable', () {
-      const event1 = RefreshFavouriteCoffeeEvent();
-      const event2 = RefreshFavouriteCoffeeEvent();
-
-      expect(event1 == event2, isTrue);
-      expect(event1.props, event2.props);
-    });
-
-    test('ToggleFavouriteCoffeeEvent is comparable', () {
-      const coffee = Coffee(url: 'https://example.com/coffee.jpg');
-      const event1 = ToggleFavouriteCoffeeEvent(coffee);
-      const event2 = ToggleFavouriteCoffeeEvent(coffee);
 
       expect(event1 == event2, isTrue);
       expect(event1.props, event2.props);

--- a/test/coffee/application/favourite_coffee_bloc_test.dart
+++ b/test/coffee/application/favourite_coffee_bloc_test.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:coffee_app/coffee/application/favourite/favourite_coffee_bloc.dart';
 import 'package:coffee_app/coffee/domain/model/coffee.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../_mock/use_case/mocked_add_favourite_coffee_use_case.dart';
 import '../../_mock/use_case/mocked_load_favourite_coffees_use_case.dart';
@@ -86,9 +87,6 @@ void main() {
         'should emits [loading, loaded] when the use case return right '
         'and the coffee is in the favourites',
         build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-          ]);
           mockedRemoveFavouriteCoffeeUseCase.mockExecute(
             const Coffee(url: 'https://example.com/coffee1.jpg'),
           );
@@ -106,32 +104,20 @@ void main() {
             Coffee(url: 'https://example.com/coffee1.jpg'),
           ),
         ),
-        expect: () => [
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loading,
-
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loaded,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-        ],
+        expect: () => <FavouriteCoffeeState>[],
+        verify: (bloc) {
+          verify(
+            () => mockedRemoveFavouriteCoffeeUseCase.execute(
+              const Coffee(url: 'https://example.com/coffee1.jpg'),
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<FavouriteCoffeeBloc, FavouriteCoffeeState>(
         'should emits [loading, loaded] when the use case return right '
         'and the coffee is not in the favourites',
         build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-            const Coffee(url: 'https://example.com/coffee1.jpg'),
-          ]);
           mockedAddFavouriteCoffeeUseCase.mockExecute(
             const Coffee(url: 'https://example.com/coffee1.jpg'),
           );
@@ -148,31 +134,20 @@ void main() {
             Coffee(url: 'https://example.com/coffee1.jpg'),
           ),
         ),
-        expect: () => [
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loading,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loaded,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-            ],
-          ),
-        ],
+        expect: () => <FavouriteCoffeeState>[],
+        verify: (bloc) {
+          verify(
+            () => mockedAddFavouriteCoffeeUseCase.execute(
+              const Coffee(url: 'https://example.com/coffee1.jpg'),
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<FavouriteCoffeeBloc, FavouriteCoffeeState>(
         'should emits [loading, toggleError] when the use case return left '
         'and the coffee is in the favourites',
         build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee1.jpg'),
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-          ]);
           mockedRemoveFavouriteCoffeeUseCase.mockRemoveCoffeeError(
             const Coffee(url: 'https://example.com/coffee1.jpg'),
           );
@@ -198,20 +173,6 @@ void main() {
               Coffee(url: 'https://example.com/coffee2.jpg'),
             ],
           ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loading,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loaded,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee1.jpg'),
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
         ],
       );
 
@@ -219,9 +180,6 @@ void main() {
         'should emits [loading, toggleError] when the use case return left '
         'and the coffee is not in the favourites',
         build: () {
-          mockedLoadFavouriteCoffeesUseCase.mockExecute([
-            const Coffee(url: 'https://example.com/coffee2.jpg'),
-          ]);
           mockedAddFavouriteCoffeeUseCase.mockAddCoffeeError(
             const Coffee(url: 'https://example.com/coffee1.jpg'),
           );
@@ -241,18 +199,6 @@ void main() {
         expect: () => [
           const FavouriteCoffeeState(
             status: FavouriteCoffeeStatus.toggleError,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loading,
-            favouriteCoffees: [
-              Coffee(url: 'https://example.com/coffee2.jpg'),
-            ],
-          ),
-          const FavouriteCoffeeState(
-            status: FavouriteCoffeeStatus.loaded,
             favouriteCoffees: [
               Coffee(url: 'https://example.com/coffee2.jpg'),
             ],

--- a/test/coffee/presentation/coffee_page_test.dart
+++ b/test/coffee/presentation/coffee_page_test.dart
@@ -47,7 +47,6 @@ void main() {
               coffee: Coffee(
                 url: 'https://example.com/coffee.jpg',
               ),
-              favouriteCoffees: [],
             ),
           );
           await tester.pumpApp(
@@ -78,7 +77,6 @@ void main() {
               coffee: Coffee(
                 url: 'https://example.com/coffee.jpg',
               ),
-              favouriteCoffees: [],
             ),
           );
           await tester.pumpApp(
@@ -113,7 +111,6 @@ void main() {
               coffee: Coffee(
                 url: 'https://example.com/coffee.jpg',
               ),
-              favouriteCoffees: [],
             ),
           );
           await tester.pumpApp(
@@ -149,7 +146,6 @@ void main() {
             CoffeeState(
               status: CoffeeStatus.loading,
               coffee: Coffee.empty(),
-              favouriteCoffees: const [],
             ),
           );
           await tester.pumpApp(
@@ -173,7 +169,6 @@ void main() {
             CoffeeState(
               status: CoffeeStatus.initial,
               coffee: Coffee.empty(),
-              favouriteCoffees: const [],
             ),
           );
           await tester.pumpApp(
@@ -199,7 +194,6 @@ void main() {
             CoffeeState(
               status: CoffeeStatus.error,
               coffee: Coffee.empty(),
-              favouriteCoffees: const [],
             ),
           );
           await tester.pumpApp(
@@ -227,7 +221,6 @@ void main() {
               coffee: Coffee(
                 url: 'https://example.com/coffee.jpg',
               ),
-              favouriteCoffees: [],
             ),
           );
           await tester.pumpApp(

--- a/test/coffee/presentation/widgets/coffee_card_widget_test.dart
+++ b/test/coffee/presentation/widgets/coffee_card_widget_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../_mock/application/mocked_favourite_coffee_bloc.dart';
-import '../../helpers/helpers.dart';
+import '../../../_mock/application/mocked_favourite_coffee_bloc.dart';
+import '../../../helpers/helpers.dart';
 
 void main() {
   const coffee = Coffee(
@@ -15,8 +15,7 @@ void main() {
   );
   late MockedFavouriteCoffeeBloc mockedFavouriteCoffeeBloc;
   setUp(() {
-    mockedFavouriteCoffeeBloc = MockedFavouriteCoffeeBloc()
-      ..mockState(FavouriteCoffeeState.initial());
+    mockedFavouriteCoffeeBloc = MockedFavouriteCoffeeBloc();
   });
 
   group(CoffeeCardWidget, () {
@@ -24,11 +23,11 @@ void main() {
       'should render with heart not filled '
       'when coffee is not favourite',
       (tester) async {
+        mockedFavouriteCoffeeBloc.mockState(FavouriteCoffeeState.initial());
         await tester.pumpApp(
           BlocProvider<FavouriteCoffeeBloc>.value(
             value: mockedFavouriteCoffeeBloc,
             child: const CoffeeCardWidget(
-              isFavourite: false,
               coffee: coffee,
             ),
           ),
@@ -42,11 +41,16 @@ void main() {
       'should render with heart filled '
       'when coffee is favourite',
       (tester) async {
+        mockedFavouriteCoffeeBloc.mockState(
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [coffee],
+          ),
+        );
         await tester.pumpApp(
           BlocProvider<FavouriteCoffeeBloc>.value(
             value: mockedFavouriteCoffeeBloc,
             child: const CoffeeCardWidget(
-              isFavourite: true,
               coffee: coffee,
             ),
           ),
@@ -60,11 +64,17 @@ void main() {
       'should call toggle favourite coffee event '
       'when heart is pressed',
       (tester) async {
+        mockedFavouriteCoffeeBloc.mockState(
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [],
+          ),
+        );
+
         await tester.pumpApp(
           BlocProvider<FavouriteCoffeeBloc>.value(
             value: mockedFavouriteCoffeeBloc,
             child: const CoffeeCardWidget(
-              isFavourite: false,
               coffee: coffee,
             ),
           ),
@@ -85,21 +95,27 @@ void main() {
       'should show snackbar with error message '
       'when toggle favourite coffee fails',
       (tester) async {
-        mockedFavouriteCoffeeBloc.mockListen(
-          [
+        mockedFavouriteCoffeeBloc
+          ..mockState(
             const FavouriteCoffeeState(
-              status: FavouriteCoffeeStatus.toggleError,
-              favouriteCoffees: [coffee],
+              status: FavouriteCoffeeStatus.loaded,
+              favouriteCoffees: [],
             ),
-          ],
-        );
+          )
+          ..mockListen(
+            [
+              const FavouriteCoffeeState(
+                status: FavouriteCoffeeStatus.toggleError,
+                favouriteCoffees: [coffee],
+              ),
+            ],
+          );
 
         await tester.pumpApp(
           BlocProvider<FavouriteCoffeeBloc>.value(
             value: mockedFavouriteCoffeeBloc,
             child: const Scaffold(
               body: CoffeeCardWidget(
-                isFavourite: false,
                 coffee: coffee,
               ),
             ),

--- a/test/coffee/presentation/widgets/coffee_error_widget_test.dart
+++ b/test/coffee/presentation/widgets/coffee_error_widget_test.dart
@@ -6,8 +6,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-import '../../_mock/application/mocked_coffee_bloc.dart';
-import '../../helpers/helpers.dart';
+import '../../../_mock/application/mocked_coffee_bloc.dart';
+import '../../../helpers/helpers.dart';
 
 void main() {
   final mockedCoffeeBloc = MockedCoffeeBloc();
@@ -20,7 +20,6 @@ void main() {
           CoffeeState(
             status: CoffeeStatus.error,
             coffee: Coffee.empty(),
-            favouriteCoffees: const [],
           ),
         );
         await tester.pumpApp(const CoffeeErrorWidget());
@@ -41,7 +40,6 @@ void main() {
           CoffeeState(
             status: CoffeeStatus.error,
             coffee: Coffee.empty(),
-            favouriteCoffees: const [],
           ),
         );
         await tester.pumpApp(

--- a/test/coffee/presentation/widgets/coffee_individual_widget_test.dart
+++ b/test/coffee/presentation/widgets/coffee_individual_widget_test.dart
@@ -10,9 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
 
-import '../../_mock/application/mocked_coffee_bloc.dart';
-import '../../_mock/application/mocked_favourite_coffee_bloc.dart';
-import '../../helpers/helpers.dart';
+import '../../../_mock/application/mocked_coffee_bloc.dart';
+import '../../../_mock/application/mocked_favourite_coffee_bloc.dart';
+import '../../../helpers/helpers.dart';
 
 void main() {
   const coffee = Coffee(url: 'https://example.com/espresso.jpg');
@@ -26,10 +26,9 @@ void main() {
     );
   final mockedBloc = MockedCoffeeBloc()
     ..mockState(
-      CoffeeState(
+      const CoffeeState(
         status: CoffeeStatus.loaded,
         coffee: coffee,
-        favouriteCoffees: favouriteCoffees,
       ),
     );
   group(CoffeeIndividualWidget, () {
@@ -42,7 +41,6 @@ void main() {
               mockedBloc,
               mockedFavouriteCoffeesBloc,
               coffee,
-              favouriteCoffees,
             ),
           ),
         );
@@ -67,7 +65,6 @@ void main() {
               mockedBloc,
               mockedFavouriteCoffeesBloc,
               coffee,
-              favouriteCoffees,
             ),
           ),
         );
@@ -94,7 +91,6 @@ void main() {
               mockedBloc,
               mockedFavouriteCoffeesBloc,
               coffee,
-              favouriteCoffees,
             ),
           ),
         );
@@ -117,10 +113,8 @@ class _TesterWidget extends StatelessWidget {
     this.coffeeBloc,
     this.favouriteCoffeeBloc,
     this.coffee,
-    this.favouriteCoffees,
   );
   final Coffee coffee;
-  final List<Coffee> favouriteCoffees;
   final CoffeeBloc coffeeBloc;
   final fav_coffee_bloc.FavouriteCoffeeBloc favouriteCoffeeBloc;
   @override
@@ -131,7 +125,6 @@ class _TesterWidget extends StatelessWidget {
         value: coffeeBloc,
         child: CoffeeIndividualWidget(
           coffee: coffee,
-          favouriteCoffees: favouriteCoffees,
         ),
       ),
     );

--- a/test/coffee/presentation/widgets/favorite_coffees_widget_test.dart
+++ b/test/coffee/presentation/widgets/favorite_coffees_widget_test.dart
@@ -7,22 +7,28 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
 
-import '../../_mock/application/mocked_favourite_coffee_bloc.dart';
-import '../../helpers/helpers.dart';
+import '../../../_mock/application/mocked_favourite_coffee_bloc.dart';
+import '../../../helpers/helpers.dart';
 
 void main() {
-  final mockedFavouriteCoffeesBloc = MockedFavouriteCoffeeBloc()
-    ..mockState(
-      FavouriteCoffeeState.initial(),
-    );
+  const coffee = Coffee(url: 'https://example.com/espresso.jpg');
+  late MockedFavouriteCoffeeBloc mockedFavouriteCoffeesBloc;
+
+  setUp(() {
+    mockedFavouriteCoffeesBloc = MockedFavouriteCoffeeBloc();
+  });
 
   group(FavoriteCoffeesWidget, () {
     testWidgets(
       'should render empty message when coffees list is empty',
       (tester) async {
-        await tester.pumpApp(
-          const FavoriteCoffeesWidget(favouriteCoffees: []),
+        mockedFavouriteCoffeesBloc.mockState(
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [],
+          ),
         );
+        await tester.pumpApp(_TesterWidget(mockedFavouriteCoffeesBloc));
 
         final emptyMessageFinder = find.text('No coffees available');
 
@@ -33,17 +39,14 @@ void main() {
     testWidgets(
       'should render coffee card when coffees list is not empty',
       (tester) async {
-        final coffees = [
-          const Coffee(url: 'https://example.com/espresso.jpg'),
-        ];
-
-        await mockNetworkImages(
-          () async => tester.pumpApp(
-            BlocProvider<FavouriteCoffeeBloc>.value(
-              value: mockedFavouriteCoffeesBloc,
-              child: FavoriteCoffeesWidget(favouriteCoffees: coffees),
-            ),
+        mockedFavouriteCoffeesBloc.mockState(
+          const FavouriteCoffeeState(
+            status: FavouriteCoffeeStatus.loaded,
+            favouriteCoffees: [coffee],
           ),
+        );
+        await mockNetworkImages(
+          () async => tester.pumpApp(_TesterWidget(mockedFavouriteCoffeesBloc)),
         );
 
         expect(find.byType(Image), findsOneWidget);
@@ -76,14 +79,7 @@ void main() {
         );
 
         await mockNetworkImages(
-          () async => tester.pumpApp(
-            BlocProvider<FavouriteCoffeeBloc>.value(
-              value: mockedFavouriteCoffeesBloc,
-              child: FavoriteCoffeesWidget(
-                favouriteCoffees: coffees,
-              ),
-            ),
-          ),
+          () async => tester.pumpApp(_TesterWidget(mockedFavouriteCoffeesBloc)),
         );
 
         expect(
@@ -120,4 +116,16 @@ void main() {
       },
     );
   });
+}
+
+class _TesterWidget extends StatelessWidget {
+  const _TesterWidget(this.mockedFavouriteCoffeesBloc);
+  final MockedFavouriteCoffeeBloc mockedFavouriteCoffeesBloc;
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<FavouriteCoffeeBloc>.value(
+      value: mockedFavouriteCoffeesBloc,
+      child: const FavoriteCoffeesWidget(),
+    );
+  }
 }


### PR DESCRIPTION
This commit refactors the `CoffeeBloc` and related widgets to remove direct handling of favorite coffees. The responsibility for managing favorite coffees is now solely within `FavouriteCoffeeBloc`.

Key changes:
- Removed `LoadFavoriteCoffeesUseCase` dependency and `RefreshFavouriteCoffeeEvent` from `CoffeeBloc`.
- `CoffeeState` no longer holds `favouriteCoffees` or the `loadingFavourites` status.
- `CoffeeIndividualWidget` and `CoffeeCardWidget` now rely on `FavouriteCoffeeBloc` to determine if a coffee is a favorite and to handle toggling favorite status.
- `CoffeeCardWidget` now uses `BlocConsumer` to listen for `toggleError` from `FavouriteCoffeeBloc` and `BlocSelector` (in `FavoriteCoffeesWidget`) or `BlocBuilder` to react to changes in the favorite coffees list.
- Removed the `isFavourite` parameter from `CoffeeCardWidget` as it's now determined internally via `FavouriteCoffeeBloc`.
- `FavoriteCoffeesWidget` now uses `BlocSelector` to get the list of favorite coffees directly from `FavouriteCoffeeBloc`.
- Updated tests to reflect these changes, including moving widget tests to a `widgets` subdirectory.
- `FavouriteCoffeeBloc` no longer emits `LoadFavouriteCoffeesEvent` after toggling a favorite, as the UI will react to the stream of favorite coffees.

This change simplifies the `CoffeeBloc` and centralizes favorite coffee logic within `FavouriteCoffeeBloc`, making the codebase more modular and easier to maintain.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
